### PR TITLE
Make Image Zoom work with Starlight Blog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,7 +13,8 @@ export default defineConfig({
       src: './src/assets/logo.png'
     },
     components: {
-      Head: './src/components/Head.astro'
+      Head: './src/components/Head.astro',
+      MarkdownContent: "./src/components/MarkdownContent.astro"
     },
     favicon: '/favicon.ico',
     social: {

--- a/src/components/MarkdownContent.astro
+++ b/src/components/MarkdownContent.astro
@@ -1,0 +1,8 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

I'm not sure if you are aware of this, but the Starlight Blog is not able to override the MarkdownContent.astro Page, which means that all blog sites dont show author infos and so on...

Fortunately for you, I have implemented a fix in this Pull Request, which should fix this for you...

The reason it doesn't work is the Starlight Image Zoom plugin, which overrides the MarkdownContent.astro file before the Starlight Blog can do it...

Have a nice day, bye!